### PR TITLE
chore(voice): cleanup — public accessors, asdict, ambiguous-pin warn, last_wake_phrase, BlueZ grace

### DIFF
--- a/pendantd/src/pendantd/__main__.py
+++ b/pendantd/src/pendantd/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from dataclasses import asdict
 from pathlib import Path
 
 from .server import Server, ControlSocketServer
@@ -46,14 +47,14 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
         router.set_pin(kind, substring)
         cfg_key = "input_device" if kind == "input" else "output_device"
         _cfg_set(cfg_key, substring)
-        return {"matched": matched.__dict__ if matched else None, "persisted": True}
+        return {"matched": asdict(matched) if matched else None, "persisted": True}
 
     def _set_aliases(params: dict) -> dict:
         aliases = [a for a in params.get("aliases", []) if isinstance(a, str)]
         _cfg_set("wake_aliases", aliases)
         base = ["claude"]
-        voice_loop._wake.set_vocabulary(base + aliases)
-        return {"vocabulary": list(voice_loop._wake.vocabulary), "persisted": True}
+        voice_loop.wake.set_vocabulary(base + aliases)
+        return {"vocabulary": list(voice_loop.wake.vocabulary), "persisted": True}
 
     async def _audio_test_loopback(params: dict) -> dict:
         from .audio.loopback import record_and_play
@@ -86,7 +87,7 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
         voice_loop.pause()
         played = 0
         try:
-            piper = voice_loop._piper  # already wired
+            piper = voice_loop.piper  # already wired
             async for chunk in piper.synthesize(text):
                 await router.write(chunk)
                 played += len(chunk)
@@ -102,8 +103,6 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
     async def _voice_test_wake(params: dict) -> dict:
         timeout_s = float(params.get("timeout_seconds", 10.0))
         # Snapshot last_wake_at; collect any new wakes during the window.
-        # NOTE: phrase is reported as "(detected)" — VoiceLoop doesn't track
-        # last_wake_phrase; adding that field is a future enhancement.
         baseline = voice_loop.last_wake_at
         event_loop = asyncio.get_event_loop()
         deadline = event_loop.time() + timeout_s
@@ -112,7 +111,7 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
             await asyncio.sleep(0.2)
             if voice_loop.last_wake_at is not None and voice_loop.last_wake_at != baseline:
                 matches.append({
-                    "phrase": "(detected)",
+                    "phrase": voice_loop.last_wake_phrase or "(detected)",
                     "timestamp_s": voice_loop.last_wake_at,
                 })
                 baseline = voice_loop.last_wake_at
@@ -120,13 +119,13 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
 
     return {
         "audio.list_devices": lambda p: {
-            "inputs": [d.__dict__ for d in list_devices().inputs],
-            "outputs": [d.__dict__ for d in list_devices().outputs],
+            "inputs": [asdict(d) for d in list_devices().inputs],
+            "outputs": [asdict(d) for d in list_devices().outputs],
         },
         "audio.get_active": lambda p: {
-            "input": router.active_input.__dict__ if router.active_input else None,
-            "output": router.active_output.__dict__ if router.active_output else None,
-            "source": "pinned" if (router._pin_in or router._pin_out) else "auto",
+            "input": asdict(router.active_input) if router.active_input else None,
+            "output": asdict(router.active_output) if router.active_output else None,
+            "source": "pinned" if (router.pin_in or router.pin_out) else "auto",
         },
         "audio.set_input": lambda p: _set_pin("input", p),
         "audio.set_output": lambda p: _set_pin("output", p),
@@ -138,10 +137,11 @@ def _build_control_handlers(router: AudioRouter, voice_loop: VoiceLoop, cfg_path
         "voice.stop": lambda p: (voice_loop.pause(), {"state": voice_loop.state.value, "paused": True})[1],
         "voice.status": lambda p: {
             "state": voice_loop.state.value,
-            "vocabulary": list(voice_loop._wake.vocabulary),
-            "current_input": router.active_input.__dict__ if router.active_input else None,
-            "current_output": router.active_output.__dict__ if router.active_output else None,
+            "vocabulary": list(voice_loop.wake.vocabulary),
+            "current_input": asdict(router.active_input) if router.active_input else None,
+            "current_output": asdict(router.active_output) if router.active_output else None,
             "last_wake_at": voice_loop.last_wake_at,
+            "last_wake_phrase": voice_loop.last_wake_phrase,
             "last_utterance": voice_loop.last_utterance,
             "latency_ms": voice_loop.last_latency_ms,
         },
@@ -267,8 +267,8 @@ async def async_main() -> int:
                 if new_cfg.get("robot_name"):
                     new_vocab.append(new_cfg["robot_name"])
                 new_vocab.extend(new_cfg.get("wake_aliases", []))
-                if new_vocab != list(voice_loop._wake.vocabulary):
-                    voice_loop._wake.set_vocabulary(new_vocab)
+                if new_vocab != list(voice_loop.wake.vocabulary):
+                    voice_loop.wake.set_vocabulary(new_vocab)
                 if new_cfg.get("sample_rate") != cfg["sample_rate"] or new_cfg.get("tts_voice") != cfg["tts_voice"]:
                     log.warning("voice.yaml: sample_rate/tts_voice changes require pendantd restart")
                 cfg.clear()

--- a/pendantd/src/pendantd/audio/devices.py
+++ b/pendantd/src/pendantd/audio/devices.py
@@ -1,8 +1,11 @@
 """Audio device discovery + auto-pick."""
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Callable, Literal
+
+log = logging.getLogger(__name__)
 
 Kind = Literal["input", "output"]
 
@@ -121,10 +124,23 @@ def pick_default(devices: list[Device], kind: Kind, all_devices: DeviceList | No
 
 
 def match_substring(devices: list[Device], substring: str) -> Device | None:
-    """Case-insensitive substring match. First match by index order wins."""
+    """Case-insensitive substring match. First match by index order wins.
+
+    Logs a warning when multiple devices match the substring, suggesting a
+    more unique pin string.
+    """
     if not substring:
         return None
     matches = [d for d in devices if d.matches(substring)]
     if not matches:
         return None
-    return min(matches, key=lambda d: d.index)
+    best = min(matches, key=lambda d: d.index)
+    if len(matches) > 1:
+        log.warning(
+            "match_substring: %d devices match %r (picking %r); "
+            "use a more unique pin to suppress this warning",
+            len(matches),
+            substring,
+            best.name,
+        )
+    return best

--- a/pendantd/src/pendantd/audio/router.py
+++ b/pendantd/src/pendantd/audio/router.py
@@ -120,6 +120,14 @@ class AudioRouter:
         self.active_input = None
         self.active_output = None
 
+    @property
+    def pin_in(self) -> str:
+        return self._pin_in
+
+    @property
+    def pin_out(self) -> str:
+        return self._pin_out
+
     def set_pin(self, kind: str, substring: str) -> None:
         if kind == "input":
             self._pin_in = substring

--- a/pendantd/src/pendantd/audio/watcher.py
+++ b/pendantd/src/pendantd/audio/watcher.py
@@ -17,25 +17,35 @@ class DeviceWatcher:
     Must be instantiated inside a running asyncio loop. Pendant
     connect/disconnect hooks share the same per-reason debounce as udev
     events. Callback exceptions are logged via stdlib logging.
+
+    ``bluez_grace_ms`` extends the debounce window for Bluetooth ``add``
+    events.  BlueZ takes 1-2 s after the udev ``add`` event to actually
+    surface the audio device, so a longer grace period avoids a spurious
+    hot-swap cycle where the device is not yet visible when the callback
+    fires.
     """
+
     def __init__(
         self,
         on_change: OnChange,
         debounce_ms: int = 300,
+        bluez_grace_ms: int = 500,
         _start_udev: bool = True,
     ) -> None:
         self._on_change = on_change
         self._debounce_s = debounce_ms / 1000.0
+        self._bluez_grace_s = bluez_grace_ms / 1000.0
         self._loop = asyncio.get_running_loop()
         self._pending: dict[str, asyncio.TimerHandle] = {}
         self._udev_task: asyncio.Task | None = None
         if _start_udev:
             self._udev_task = self._loop.create_task(self._run_udev())
 
-    def _emit(self, reason: str) -> None:
+    def _emit(self, reason: str, *, delay_s: float | None = None) -> None:
         if reason in self._pending:
             self._pending[reason].cancel()
-        handle = self._loop.call_later(self._debounce_s, self._fire, reason)
+        effective = delay_s if delay_s is not None else self._debounce_s
+        handle = self._loop.call_later(effective, self._fire, reason)
         self._pending[reason] = handle
 
     def _fire(self, reason: str) -> None:
@@ -57,6 +67,19 @@ class DeviceWatcher:
     def on_pendant_disconnect(self) -> None:
         self._emit("pendant-disconnected")
 
+    @staticmethod
+    def _is_bluez(device: object) -> bool:
+        """Return True when the udev device looks like a BlueZ audio device."""
+        name = getattr(device, "sys_name", "") or ""
+        subsystem = getattr(device, "subsystem", "") or ""
+        n = name.lower()
+        return (
+            subsystem == "bluetooth"
+            or "bluez" in n
+            or "bluetooth" in n
+            or "a2dp" in n
+        )
+
     async def _run_udev(self) -> None:  # pragma: no cover - hardware
         try:
             import pyudev
@@ -72,7 +95,14 @@ class DeviceWatcher:
                 continue
             action = device.action
             if action in ("add", "remove", "change"):
-                self._emit(f"usb-{action}")
+                # Use the longer BlueZ grace period for Bluetooth add events so
+                # the audio device has time to surface before the callback fires.
+                delay = (
+                    self._bluez_grace_s
+                    if action == "add" and self._is_bluez(device)
+                    else None
+                )
+                self._emit(f"usb-{action}", delay_s=delay)
 
     async def stop(self) -> None:
         if self._udev_task is not None:

--- a/pendantd/src/pendantd/voice/loop.py
+++ b/pendantd/src/pendantd/voice/loop.py
@@ -55,6 +55,7 @@ class VoiceLoop:
         self.state = LoopState.IDLE
         self.history: "collections.deque[LoopState]" = collections.deque(maxlen=64)
         self.last_wake_at: float | None = None
+        self.last_wake_phrase: str | None = None
         self.last_utterance: str = ""
         self._stop = asyncio.Event()
         self._paused: asyncio.Event = asyncio.Event()  # set = paused; clear = running
@@ -76,6 +77,14 @@ class VoiceLoop:
     @property
     def paused(self) -> bool:
         return self._paused.is_set()
+
+    @property
+    def wake(self) -> _WakeMatcher:
+        return self._wake
+
+    @property
+    def piper(self) -> object:
+        return self._piper
 
     async def announce(self, text: str) -> None:
         await self._announce_q.put(text)
@@ -139,6 +148,7 @@ class VoiceLoop:
                 if not hits:
                     continue
 
+                self.last_wake_phrase = hits[0].get("phrase")
                 self.last_wake_at = loop.time()
                 start_time = self.last_wake_at
                 self._set_state(LoopState.THINKING)

--- a/pendantd/tests/test_audio_devices.py
+++ b/pendantd/tests/test_audio_devices.py
@@ -1,3 +1,5 @@
+import logging
+
 from pendantd.audio.devices import (
     Device,
     DeviceList,
@@ -42,6 +44,21 @@ def test_match_substring_returns_first_index_winner_when_ambiguous():
     devs = list_devices(query=lambda: FAKE)
     matched = match_substring(devs.outputs, "USB")
     assert matched.name == "Jabra SPEAK 410 USB"  # first by index
+
+
+def test_match_substring_warns_on_multiple_matches(caplog):
+    # Build a device list where multiple entries match the substring.
+    fake_ambiguous = [
+        {"index": 0, "name": "USB Headset A", "max_input_channels": 1, "max_output_channels": 2,
+         "default_samplerate": 16000.0, "hostapi": 0},
+        {"index": 1, "name": "USB Headset B", "max_input_channels": 1, "max_output_channels": 2,
+         "default_samplerate": 16000.0, "hostapi": 0},
+    ]
+    devs = list_devices(query=lambda: fake_ambiguous)
+    with caplog.at_level(logging.WARNING, logger="pendantd.audio.devices"):
+        matched = match_substring(devs.outputs, "USB")
+    assert matched.name == "USB Headset A"  # first by index
+    assert any("match_substring" in rec.message and "2" in rec.message for rec in caplog.records)
 
 
 def test_match_substring_returns_none_when_missing():

--- a/pendantd/tests/test_audio_watcher.py
+++ b/pendantd/tests/test_audio_watcher.py
@@ -50,15 +50,15 @@ def test_watcher_requires_running_loop():
 
 @pytest.mark.asyncio
 async def test_watcher_bluez_grace_fires_with_longer_delay():
-    """_emit with a custom delay fires later than the default debounce."""
-    fired_times: list[float] = []
+    """_emit with a longer delay_s fires measurably later than the default debounce."""
+    fired_times: list[tuple[str, float]] = []
     loop = asyncio.get_running_loop()
 
     async def on_change(reason: str):
-        fired_times.append(loop.time())
+        fired_times.append((reason, loop.time()))
 
-    # Use a long debounce (100ms) and a longer bluez_grace (300ms) so the
-    # difference is measurable without relying on real hardware.
+    # Use debounce=50ms and bluez_grace=300ms so the difference is measurable
+    # without relying on real hardware.
     w = DeviceWatcher(
         on_change=on_change,
         debounce_ms=50,
@@ -66,12 +66,12 @@ async def test_watcher_bluez_grace_fires_with_longer_delay():
         _start_udev=False,
     )
     t0 = loop.time()
-    # Simulate a normal usb-add (debounce=50ms) and a bluez add (grace=300ms)
     w._emit("usb-add")
     w._emit("bluez-add", delay_s=w._bluez_grace_s)
     await asyncio.sleep(0.5)
-    # bluez-add should fire after the grace period (≥ 300ms); usb-add fires at 50ms
-    assert len(fired_times) == 2
-    # Verify both fired; order might vary but bluez fires later overall
-    # (We check the watcher stored the bluez grace correctly.)
-    assert w._bluez_grace_s == pytest.approx(0.3)
+
+    times = dict(fired_times)
+    assert set(times) == {"usb-add", "bluez-add"}
+    # Normal debounce fires quickly (within 200ms); grace fires after ≥250ms
+    assert times["usb-add"] - t0 < 0.2, "normal debounce took too long"
+    assert times["bluez-add"] - t0 >= 0.25, "bluez grace delay not applied"

--- a/pendantd/tests/test_audio_watcher.py
+++ b/pendantd/tests/test_audio_watcher.py
@@ -46,3 +46,32 @@ def test_watcher_requires_running_loop():
     async def _boom(_): pass
     with pytest.raises(RuntimeError):
         DeviceWatcher(on_change=_boom, _start_udev=False)
+
+
+@pytest.mark.asyncio
+async def test_watcher_bluez_grace_fires_with_longer_delay():
+    """_emit with a custom delay fires later than the default debounce."""
+    fired_times: list[float] = []
+    loop = asyncio.get_running_loop()
+
+    async def on_change(reason: str):
+        fired_times.append(loop.time())
+
+    # Use a long debounce (100ms) and a longer bluez_grace (300ms) so the
+    # difference is measurable without relying on real hardware.
+    w = DeviceWatcher(
+        on_change=on_change,
+        debounce_ms=50,
+        bluez_grace_ms=300,
+        _start_udev=False,
+    )
+    t0 = loop.time()
+    # Simulate a normal usb-add (debounce=50ms) and a bluez add (grace=300ms)
+    w._emit("usb-add")
+    w._emit("bluez-add", delay_s=w._bluez_grace_s)
+    await asyncio.sleep(0.5)
+    # bluez-add should fire after the grace period (≥ 300ms); usb-add fires at 50ms
+    assert len(fired_times) == 2
+    # Verify both fired; order might vary but bluez fires later overall
+    # (We check the watcher stored the bluez grace correctly.)
+    assert w._bluez_grace_s == pytest.approx(0.3)

--- a/pendantd/tests/test_voice_loop.py
+++ b/pendantd/tests/test_voice_loop.py
@@ -228,3 +228,23 @@ async def test_voice_loop_tracks_latency_ms_after_handle_utterance():
     await task
     assert loop.last_latency_ms is not None
     assert loop.last_latency_ms > 0  # measurable elapsed time
+
+
+@pytest.mark.asyncio
+async def test_voice_loop_last_wake_phrase_set_after_wake():
+    """last_wake_phrase tracks which vocabulary entry fired."""
+    frames = [b"\x00" * 320 for _ in range(40)]
+    router = FakeRouter(frames)
+    loop = VoiceLoop(
+        router=router, wake=StubWake(fire_after_n_frames=2),
+        endpoint_factory=lambda on_end: StubEndpoint(on_end, fire_after=2),
+        whisper=StubWhisper(), agent=StubAgent(), piper=StubPiper(),
+        wake_step_seconds=0.01,
+    )
+    assert loop.last_wake_phrase is None
+    task = asyncio.create_task(loop.run())
+    await asyncio.sleep(0.4)
+    await loop.stop()
+    await task
+    # StubWake returns [{"phrase": "bob", ...}] when it fires
+    assert loop.last_wake_phrase == "bob"


### PR DESCRIPTION
## Summary

Addresses minor cleanup items M2–M6 from #2:

- **M2** — `VoiceLoop` gains `.wake` / `.piper` properties; `AudioRouter` gains `.pin_in` / `.pin_out` properties. All underscored attribute accesses in `__main__.py` (including `_on_voice_cfg_change`) replaced with the new public accessors.
- **M3** — `dataclasses.asdict(d)` replaces `d.__dict__` for `Device` serialization in all four call sites in `__main__.py`.
- **M4** — `match_substring` in `audio/devices.py` logs a `logging.warning` when multiple devices match the substring, suggesting a more unique pin. New test verifies the warning fires via `caplog`.
- **M5** — `DeviceWatcher` gains a `bluez_grace_ms` constructor parameter (default 500 ms). `_emit` accepts an optional `delay_s` keyword; `_run_udev` passes `delay_s=bluez_grace_s` for Bluetooth `add` events via `_is_bluez()` detection. New test verifies relative fire timing without hardware.
- **M6** — `VoiceLoop.last_wake_phrase: str | None` tracks the vocabulary phrase that triggered the last wake. Assigned in `run()` on wake hit. Surfaced in `voice.status` and `voice.test_wake` responses in `__main__.py`. New test confirms `last_wake_phrase == "bob"` after `StubWake` fires.

## Test plan

- [ ] `cd pendantd && PYTHONPATH=src pytest -q` — 94 passed, 1 skipped (up from 91 + 1)
- [ ] No new regressions in existing tests

Closes part of #2.