### PR TITLE
feat(voice): layer manifest voice: block under sidecar voice.yaml

### DIFF
--- a/pendantd/pyproject.toml
+++ b/pendantd/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
   "faster-whisper>=1.0",
   "pyudev>=0.24",
   "mcp>=1.0",
+  # voice block parsing from ROBOT.md (rcan-spec §8.7). Soft dependency:
+  # voice_cfg.py falls back to sidecar-only mode if rcan isn't importable,
+  # but pendantd is fundamentally about ROBOT.md so we pin it as required.
+  "rcan>=3.3.3",
 ]
 
 [project.optional-dependencies]

--- a/pendantd/src/pendantd/__main__.py
+++ b/pendantd/src/pendantd/__main__.py
@@ -154,15 +154,6 @@ async def async_main() -> int:
     cfg_dir = Path(os.environ.get("PENDANTD_CONFIG", str(Path.home() / ".config" / "robot-md-pendant")))
     cfg_path = cfg_dir / "voice.yaml"
 
-    # Load voice config; fall back to minimal defaults if file absent so the
-    # daemon can still serve WS without voice hardware configured yet.
-    try:
-        cfg = load_voice_cfg(cfg_path)
-    except (FileNotFoundError, VoiceConfigError) as exc:
-        log.warning("voice.yaml not loaded (%s); voice pipeline disabled", exc)
-        cfg = None
-
-    buttons = load_buttons(cfg_dir / "buttons.yaml")
     robot_md_path = os.environ.get("ROBOT_MD_PATH")
     if not robot_md_path:
         log.error(
@@ -171,6 +162,20 @@ async def async_main() -> int:
             "ROBOT_MD_PATH=/home/pi/robot/ROBOT.md"
         )
         return 2
+
+    # Load voice config; sidecar yaml is layered on top of the manifest's
+    # optional voice: block (rcan-spec §8.7) so robot-portable defaults
+    # (aliases, language, tts_voice) flow through and host-specific fields
+    # (devices, sample rate, wake_word) override per host. Fall back to
+    # minimal defaults if file absent so the daemon can still serve WS
+    # without voice hardware configured yet.
+    try:
+        cfg = load_voice_cfg(cfg_path, manifest_path=robot_md_path)
+    except (FileNotFoundError, VoiceConfigError) as exc:
+        log.warning("voice.yaml not loaded (%s); voice pipeline disabled", exc)
+        cfg = None
+
+    buttons = load_buttons(cfg_dir / "buttons.yaml")
     mcp = MCPBridge(command=["npx", "robot-md-mcp", "--robot", robot_md_path])
     await mcp.start()
     try:
@@ -274,7 +279,11 @@ async def async_main() -> int:
                 cfg.clear()
                 cfg.update(new_cfg)
 
-            cfg_watcher = VoiceCfgWatcher(cfg_path, on_change=_on_voice_cfg_change)
+            cfg_watcher = VoiceCfgWatcher(
+                cfg_path,
+                on_change=_on_voice_cfg_change,
+                manifest_path=robot_md_path,
+            )
             await cfg_watcher.start()
 
             async def on_device_change(reason: str) -> None:

--- a/pendantd/src/pendantd/voice_cfg.py
+++ b/pendantd/src/pendantd/voice_cfg.py
@@ -1,42 +1,121 @@
 from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 from typing import Callable
+
 import yaml
 from watchfiles import awatch
 
-REQUIRED_KEYS = ("wake_word", "tts_voice")
+# Sidecar-only required keys. tts_voice is not in this set since rcan-spec
+# v3.3 §8.7 lets the manifest's voice: block supply it (see the merge in
+# load_voice_cfg below).
+SIDECAR_REQUIRED = ("wake_word",)
+
 DEFAULTS: dict = {
     "robot_name": "",
     "wake_aliases": [],
+    "language": "en-US",  # rcan-spec §8.7 default
     "input_device": "",
     "output_device": "",
     "sample_rate": 16000,
 }
 
+
 class VoiceConfigError(ValueError):
     pass
 
-def load_voice_cfg(path) -> dict:
-    data = yaml.safe_load(Path(path).read_text()) or {}
-    if not isinstance(data, dict):
+
+def load_manifest_voice(manifest_path) -> dict:
+    """Extract voice defaults from a ROBOT.md manifest.
+
+    Returns a dict in the sidecar's shape so it can be layered under
+    ``load_voice_cfg``. Maps ``metadata.robot_name`` → ``robot_name`` and
+    the optional ``voice:`` block (rcan-spec v3.3 §8.7) →
+    ``wake_aliases`` / ``tts_voice`` / ``language``.
+
+    Returns ``{}`` when ``manifest_path`` is ``None`` or when the ``rcan``
+    package is not importable (sidecar-only mode preserved for environments
+    that don't depend on rcan-py).
+    """
+    if manifest_path is None:
+        return {}
+    try:
+        from rcan import from_manifest
+    except ImportError:
+        return {}
+
+    info = from_manifest(manifest_path)
+    out: dict = {}
+    if info.robot_name:
+        out["robot_name"] = info.robot_name
+    if info.voice:
+        if "aliases" in info.voice:
+            out["wake_aliases"] = list(info.voice["aliases"])
+        if "tts_voice" in info.voice:
+            out["tts_voice"] = info.voice["tts_voice"]
+        if "language" in info.voice:
+            out["language"] = info.voice["language"]
+    return out
+
+
+def load_voice_cfg(path, manifest_path=None) -> dict:
+    """Load voice config with layered precedence.
+
+    Layers (lowest → highest):
+      1. Hardcoded ``DEFAULTS``
+      2. Manifest ``voice:`` block (rcan-spec §8.7) when ``manifest_path`` set
+      3. Sidecar ``voice.yaml``
+
+    Sidecar values override manifest values, which override defaults.
+    Pass ``manifest_path=None`` (the default) for the original sidecar-only
+    behavior.
+
+    ``wake_word`` MUST appear in the sidecar — manifest voice block doesn't
+    carry it (the `name` field is the primary wake word; `aliases` are
+    extras). ``tts_voice`` is required after merge but MAY come from either
+    layer.
+    """
+    sidecar = yaml.safe_load(Path(path).read_text()) or {}
+    if not isinstance(sidecar, dict):
         raise VoiceConfigError("voice config must be a mapping")
-    for key in REQUIRED_KEYS:
-        if key not in data:
-            raise VoiceConfigError(f"missing required key: {key!r}")
-    for key, default in DEFAULTS.items():
-        data.setdefault(key, default if not isinstance(default, list) else list(default))
-    return data
+
+    for key in SIDECAR_REQUIRED:
+        if key not in sidecar:
+            raise VoiceConfigError(f"missing required key: {key!r} (sidecar)")
+
+    manifest_defaults = load_manifest_voice(manifest_path)
+
+    out: dict = {
+        k: (list(v) if isinstance(v, list) else v) for k, v in DEFAULTS.items()
+    }
+    out.update(manifest_defaults)
+    out.update(sidecar)
+
+    if "tts_voice" not in out:
+        raise VoiceConfigError(
+            "missing required key: 'tts_voice' — provide in sidecar voice.yaml "
+            "or in the ROBOT.md voice: block"
+        )
+
+    return out
+
 
 class VoiceCfgWatcher:
-    def __init__(self, path, on_change: Callable[[dict], None]) -> None:
+    def __init__(
+        self,
+        path,
+        on_change: Callable[[dict], None],
+        manifest_path=None,
+    ) -> None:
         self._path = Path(path)
+        self._manifest_path = manifest_path
         self._on_change = on_change
         self._task: asyncio.Task | None = None
         self._stop_event: asyncio.Event | None = None
 
     async def start(self) -> None:
-        self._on_change(load_voice_cfg(self._path))
+        self._on_change(load_voice_cfg(self._path, self._manifest_path))
         self._stop_event = asyncio.Event()
         self._task = asyncio.create_task(self._watch())
         # Give watchfiles time to spin up its underlying watcher so changes
@@ -56,6 +135,6 @@ class VoiceCfgWatcher:
         assert self._stop_event is not None
         async for _changes in awatch(self._path, stop_event=self._stop_event, step=50):
             try:
-                self._on_change(load_voice_cfg(self._path))
+                self._on_change(load_voice_cfg(self._path, self._manifest_path))
             except VoiceConfigError:
                 pass  # Keep prior config; error surfacing in a later task

--- a/pendantd/tests/test_voice_cfg.py
+++ b/pendantd/tests/test_voice_cfg.py
@@ -41,3 +41,107 @@ async def test_watcher_triggers_on_change(tmp_path):
         if len(updates) >= 2: break
     await w.stop()
     assert updates[-1]["wake_word"] is True
+
+
+# --- v3.3 §8.7 manifest voice block integration ---
+
+
+_BOB_MANIFEST_WITH_VOICE = """\
+---
+rcan_version: '3.3'
+metadata:
+  robot_name: bob
+  rrn: RRN-000000000003
+voice:
+  aliases: [bobby, hey-bob]
+  language: en-US
+  tts_voice: en_US-amy-low
+---
+
+# Bob
+"""
+
+
+_BOB_MANIFEST_NO_VOICE = """\
+---
+rcan_version: '3.3'
+metadata:
+  robot_name: bob
+  rrn: RRN-000000000003
+---
+
+# Bob
+"""
+
+
+def test_load_voice_cfg_pulls_defaults_from_manifest(tmp_path):
+    """When manifest_path is provided, voice block fills in defaults
+    that the sidecar can override."""
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text(_BOB_MANIFEST_WITH_VOICE)
+
+    sidecar = tmp_path / "voice.yaml"
+    sidecar.write_text("wake_word: claude\n")  # no tts_voice in sidecar
+
+    cfg = load_voice_cfg(sidecar, manifest_path=manifest)
+    assert cfg["wake_word"] == "claude"
+    assert cfg["robot_name"] == "bob"  # from manifest
+    assert cfg["wake_aliases"] == ["bobby", "hey-bob"]  # from manifest
+    assert cfg["tts_voice"] == "en_US-amy-low"  # from manifest
+    assert cfg["language"] == "en-US"  # from manifest (matches default but sourced)
+
+
+def test_sidecar_overrides_manifest(tmp_path):
+    """Sidecar values take precedence over manifest defaults — host customization wins."""
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text(_BOB_MANIFEST_WITH_VOICE)
+
+    sidecar = tmp_path / "voice.yaml"
+    sidecar.write_text(
+        "wake_word: claude\n"
+        "wake_aliases: [host-only-alias]\n"
+        "tts_voice: en_US-amy-medium\n"
+    )
+
+    cfg = load_voice_cfg(sidecar, manifest_path=manifest)
+    assert cfg["wake_aliases"] == ["host-only-alias"]  # sidecar wins
+    assert cfg["tts_voice"] == "en_US-amy-medium"  # sidecar wins
+
+
+def test_manifest_without_voice_block_keeps_sidecar_authoritative(tmp_path):
+    """Manifest with no voice block: only robot_name flows through; sidecar
+    must still supply tts_voice."""
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text(_BOB_MANIFEST_NO_VOICE)
+
+    sidecar = tmp_path / "voice.yaml"
+    sidecar.write_text("wake_word: claude\ntts_voice: en_US-amy-medium\n")
+
+    cfg = load_voice_cfg(sidecar, manifest_path=manifest)
+    assert cfg["robot_name"] == "bob"  # from manifest
+    assert cfg["wake_aliases"] == []  # default (no manifest voice block)
+    assert cfg["tts_voice"] == "en_US-amy-medium"
+
+
+def test_tts_voice_required_after_merge(tmp_path):
+    """Sidecar without tts_voice + manifest without voice block → still errors."""
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text(_BOB_MANIFEST_NO_VOICE)
+
+    sidecar = tmp_path / "voice.yaml"
+    sidecar.write_text("wake_word: claude\n")  # no tts_voice anywhere
+
+    with pytest.raises(VoiceConfigError, match="tts_voice"):
+        load_voice_cfg(sidecar, manifest_path=manifest)
+
+
+def test_manifest_path_none_preserves_sidecar_only_behavior(tmp_path):
+    """The default (manifest_path=None) keeps the original sidecar-only
+    semantics — backward compat."""
+    sidecar = tmp_path / "voice.yaml"
+    sidecar.write_text("wake_word: claude\ntts_voice: en_US-amy-medium\n")
+
+    cfg = load_voice_cfg(sidecar)  # no manifest_path
+    assert cfg["wake_word"] == "claude"
+    assert cfg["tts_voice"] == "en_US-amy-medium"
+    assert cfg["robot_name"] == ""  # default, no manifest


### PR DESCRIPTION
## Summary

Closes the cascade started by rcan-spec PR continuonai/rcan-spec#198 → rcan-py 3.3.3 → rcan-ts 3.4.2. Pendant now reads the optional rcan-spec v3.3 §8.7 \`voice:\` block from ROBOT.md and layers it under the existing sidecar \`voice.yaml\`.

**Layered precedence (lowest → highest):**
1. Hardcoded \`DEFAULTS\` (in voice_cfg.py)
2. Manifest \`voice:\` block (when \`ROBOT_MD_PATH\` is set — already required)
3. Sidecar \`voice.yaml\`

Robot-portable defaults flow through the manifest; host-level customization stays in the sidecar.

## Mapping (manifest → sidecar key)

| Manifest | Sidecar | Notes |
|---|---|---|
| \`voice.aliases\` | \`wake_aliases\` | Extras beyond robot \`name\` |
| \`voice.language\` | \`language\` | NEW field; default \`en-US\` |
| \`voice.tts_voice\` | \`tts_voice\` | Was sidecar-only; now layered |

\`wake_word\` MUST still appear in the sidecar — the manifest's \`name\` is the primary wake word and \`voice.aliases\` are extras. \`tts_voice\` is required after merge but MAY come from either layer.

## API changes (additive, backward compatible)

- \`load_voice_cfg(path, manifest_path=None)\` — \`manifest_path\` is new + optional. Default behavior unchanged.
- \`VoiceCfgWatcher(path, on_change, manifest_path=None)\` — same.
- New: \`load_manifest_voice(manifest_path)\` helper for callers that want manifest-only.

If \`rcan\` is not importable, \`load_manifest_voice\` returns \`{}\` — pendantd keeps sidecar-only mode for environments without rcan-py installed.

## Tests

- 4 original tests preserved (backward-compat sidecar-only paths)
- 5 new tests covering the layered merge:
  - manifest defaults flow through when sidecar is sparse
  - sidecar overrides manifest for shared keys
  - manifest without voice block → only \`robot_name\` flows; sidecar must supply \`tts_voice\`
  - \`tts_voice\` required after merge (errors if neither layer has it)
  - \`manifest_path=None\` preserves old sidecar-only behavior

9/9 voice_cfg tests pass; 95/95 full pendantd suite passes.

## End-to-end

Bob's \`ROBOT.md\` (committed earlier today) now has:
\`\`\`yaml
voice:
  aliases: [bobby, hey-bob]
  language: en-US
  tts_voice: en_US-amy-medium
\`\`\`

With this PR landed and \`ROBOT_MD_PATH=/path/to/bob/ROBOT.md\`, pendantd reads those as defaults; \`bob/.robot-md/voice.yaml\` only needs \`wake_word\` and host-specific device fields.

## Test plan

- [x] 9/9 voice_cfg tests pass
- [x] 95/95 full pendantd suite passes
- [ ] CI green
- [ ] Live bob test (manual, after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)